### PR TITLE
fix(ci): Ignore key storage inside build.json file. File not found in capacitor project

### DIFF
--- a/common/orb.yml
+++ b/common/orb.yml
@@ -257,7 +257,7 @@ commands:
             - attach_workspace:
                 at: << parameters.path >>
       - when:
-          condition: 
+          condition:
             equal: [ 'standalone', << parameters.scanner >> ]
           steps:
             - run:
@@ -286,7 +286,7 @@ commands:
                 paths:
                   - ~/.sonar
       - when:
-          condition: 
+          condition:
             equal: [ 'gradle', << parameters.scanner >> ]
           steps:
             - run:
@@ -455,8 +455,8 @@ commands:
               git clone --quiet --depth=1 << parameters.dist-certs-repo-url >> ${CERT_DIR}
               STORE_PASS=$(jq -r '.[] | select(.distribution == true and .name == "<< parameters.key-name >>").storePassword' $CERT_DIR/keystores.json)
               KEYSTORE_PASS=$(jq -r '.[] | select(.distribution == true and .name == "<< parameters.key-name >>").password' $CERT_DIR/keystores.json)
-              sed -i 's/KEYSTORE_STORE_PASS_PLACEHOLDER/'"$STORE_PASS"'/' build.json
-              sed -i 's/KEYSTORE_PASS_PLACEHOLDER/'"$KEYSTORE_PASS"'/' build.json
+              sed -i 's/KEYSTORE_STORE_PASS_PLACEHOLDER/'"$STORE_PASS"'/' build.json 2>/dev/null
+              sed -i 's/KEYSTORE_PASS_PLACEHOLDER/'"$KEYSTORE_PASS"'/' build.json 2>/dev/null
             fi
   fix-node-permissions:
     description: Fixes global node_modules write access


### PR DESCRIPTION
Actualmente en algunos proyectos se obtiene la keystore de android del repo de bitbucket  por lo que necesitamos utilizar el comando para que descargue el fichero.

Lo que pasa es que para capacitor no existe el fichero build.json donde intenta poner los datos del fichero. Por eso sería necesario que se ignorara el error si no existe el fichero y que continuara el proceso (posteriormente en nativo se gestiona la actualización del fichero que toca leyendo la info del fichero)
