### PR TITLE
V2.1

### DIFF
--- a/common/orb.yml
+++ b/common/orb.yml
@@ -530,30 +530,10 @@ commands:
           command: npm-cli-adduser
   notify:
     description: Send Slack notification
-    parameters:
-      template:
-        type: string
-        default: "{\n\t\"blocks\": [\n\t\t{\n\t\t\t\"type\": \"section\",\n\t\t\t\"text\": {\n\t\t\t\t\"type\": \"plain_text\",\n\t\t\t\t\"text\": \":red_circle: Failed: ${CIRCLE_USERNAME} workflow (${CIRCLE_JOB}) in ${CIRCLE_PROJECT_REPONAME} (${CIRCLE_BRANCH})\",\n\t\t\t\t\"emoji\": true\n\t\t\t}\n\t\t},\n\t\t{\n\t\t\t\"type\": \"actions\",\n\t\t\t\"elements\": [\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"button\",\n\t\t\t\t\t\"text\": {\n\t\t\t\t\t\t\"type\": \"plain_text\",\n\t\t\t\t\t\t\"text\": \"View ${CIRCLE_PROJECT_REPONAME} ${CIRCLE_JOB} job\"\n\t\t\t\t\t},\n\t\t\t\t\t\"url\": \"${CIRCLE_BUILD_URL}\"\n\t\t\t\t}\n\t\t\t]\n\t\t}\n\t]\n}\n"
-      slack-access-token:
-        type: string
-        default: ''
-      slack-default-channel:
-        type: string
-        default: ''
     steps:
-      - when:
-          condition: << parameters.slack-access-token >> && << parameters.slack-default-channel >>
-          steps:
-            - run:
-                name: "Setup Slack environment variables"
-                command: |
-                  echo "export SLACK_ACCESS_TOKEN=<< parameters.slack-access-token >>" >> "$BASH_ENV"
-                  echo "export SLACK_DEFAULT_CHANNEL=<< parameters.slack-default-channel >>" >> "$BASH_ENV"
-                  source "$BASH_ENV"
-                when: on_fail
       - slack/notify:
           event: fail
-          custom: << parameters.template >>
+          custom: "{\n\t\"blocks\": [\n\t\t{\n\t\t\t\"type\": \"section\",\n\t\t\t\"text\": {\n\t\t\t\t\"type\": \"plain_text\",\n\t\t\t\t\"text\": \":red_circle: Failed: ${CIRCLE_USERNAME} workflow (${CIRCLE_JOB}) in ${CIRCLE_PROJECT_REPONAME} (${CIRCLE_BRANCH})\",\n\t\t\t\t\"emoji\": true\n\t\t\t}\n\t\t},\n\t\t{\n\t\t\t\"type\": \"actions\",\n\t\t\t\"elements\": [\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"button\",\n\t\t\t\t\t\"text\": {\n\t\t\t\t\t\t\"type\": \"plain_text\",\n\t\t\t\t\t\t\"text\": \"View ${CIRCLE_PROJECT_REPONAME} ${CIRCLE_JOB} job\"\n\t\t\t\t\t},\n\t\t\t\t\t\"url\": \"${CIRCLE_BUILD_URL}\"\n\t\t\t\t}\n\t\t\t]\n\t\t}\n\t]\n}\n"
   install-onepassword-cli:
     description: Install 1Password CLI
     parameters:

--- a/common/orb.yml
+++ b/common/orb.yml
@@ -13,6 +13,7 @@ cache-key-sonar-gradle: &cache-key-sonar-gradle
 orbs:
   aws-cli: circleci/aws-cli@3
   slack: circleci/slack@4
+  1password: onepassword/secrets@1.0.0
 
 executors:
   node:
@@ -203,26 +204,50 @@ commands:
       config:
         type: string
     steps:
-     - run:
-        name: Starting VPN connection
-        command: |
-          wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg > /tmp/repo-public.gpg
-          sudo apt-key add /tmp/repo-public.gpg
-          sudo rm -f /var/lib/apt/lists/lock
-          sudo rm -f /var/cache/apt/archives/lock
-          sudo rm -f /var/lib/dpkg/lock
-          sudo dpkg --configure -a
-          sudo bash -c 'echo "deb http://build.openvpn.net/debian/openvpn/release/2.4 trusty main" > /etc/apt/sources.list.d/openvpn-aptrepo.list'
-          sudo apt-get update || true
-          sudo apt-get install openvpn
-          echo "<< parameters.config >>" > /tmp/vpn.conf
-          echo "<< parameters.user >>" > /tmp/auth.txt
-          echo "<< parameters.password >>" >> /tmp/auth.txt
-          sudo bash -c "base64 -d /tmp/vpn.conf > /etc/openvpn/vpn.conf"
-          sudo cp /tmp/auth.txt /etc/openvpn/auth.txt
-          rm -f /tmp/vpn.conf /tmp/auth.txt
-          sudo openvpn --daemon --config /etc/openvpn/vpn.conf
-          sleep 10
+      - run:
+          name: Starting VPN connection
+          command: |
+            wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg > /tmp/repo-public.gpg
+            sudo apt-key add /tmp/repo-public.gpg
+            sudo rm -f /var/lib/apt/lists/lock
+            sudo rm -f /var/cache/apt/archives/lock
+            sudo rm -f /var/lib/dpkg/lock
+            sudo dpkg --configure -a
+            sudo bash -c 'echo "deb http://build.openvpn.net/debian/openvpn/release/2.4 trusty main" > /etc/apt/sources.list.d/openvpn-aptrepo.list'
+            sudo apt-get update || true
+            sudo apt-get install openvpn
+            echo "<< parameters.config >>" > /tmp/vpn.conf
+            echo "<< parameters.user >>" > /tmp/auth.txt
+            echo "<< parameters.password >>" >> /tmp/auth.txt
+            sudo bash -c "base64 -d /tmp/vpn.conf > /etc/openvpn/vpn.conf"
+            sudo cp /tmp/auth.txt /etc/openvpn/auth.txt
+            rm -f /tmp/vpn.conf /tmp/auth.txt
+            sudo openvpn --daemon --config /etc/openvpn/vpn.conf
+            sleep 10
+  mac_vpn:
+    description: Start VPN connection for MacOS
+    parameters:
+      user:
+        type: string
+      password:
+        type: string
+      config:
+        type: string
+    steps:
+      - run:
+          name: Start VPN connection
+          command: |
+            brew install openvpn
+            echo "<< parameters.config >>" > /tmp/vpn.conf
+            echo "<< parameters.user >>" > /tmp/auth.txt
+            echo "<< parameters.password >>" >> /tmp/auth.txt
+            bash -c "base64 -d /tmp/vpn.conf > /opt/homebrew/etc/openvpn/openvpn.conf"
+            sed -i '' 's/\/etc\/openvpn/\/opt\/homebrew\/etc\/openvpn/' /opt/homebrew/etc/openvpn/openvpn.conf
+            sed -i '' 's/^[^#]*[up|down][[:blank:]]*\/opt\/homebrew\/etc\/openvpn\/update-resolv-conf/#&/' /opt/homebrew/etc/openvpn/openvpn.conf
+            cp /tmp/auth.txt /opt/homebrew/etc/openvpn/auth.txt
+            rm -f /tmp/vpn.conf /tmp/auth.txt
+            sudo brew services start openvpn
+            sleep 10
   bitbucket-downloads:
     description: Upload artifacts to BitBucket Downloads
     parameters:
@@ -505,11 +530,53 @@ commands:
           command: npm-cli-adduser
   notify:
     description: Send Slack notification
+    parameters:
+      template:
+        type: string
+        default: "{\n\t\"blocks\": [\n\t\t{\n\t\t\t\"type\": \"section\",\n\t\t\t\"text\": {\n\t\t\t\t\"type\": \"plain_text\",\n\t\t\t\t\"text\": \":red_circle: Failed: ${CIRCLE_USERNAME} workflow (${CIRCLE_JOB}) in ${CIRCLE_PROJECT_REPONAME} (${CIRCLE_BRANCH})\",\n\t\t\t\t\"emoji\": true\n\t\t\t}\n\t\t},\n\t\t{\n\t\t\t\"type\": \"actions\",\n\t\t\t\"elements\": [\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"button\",\n\t\t\t\t\t\"text\": {\n\t\t\t\t\t\t\"type\": \"plain_text\",\n\t\t\t\t\t\t\"text\": \"View ${CIRCLE_PROJECT_REPONAME} ${CIRCLE_JOB} job\"\n\t\t\t\t\t},\n\t\t\t\t\t\"url\": \"${CIRCLE_BUILD_URL}\"\n\t\t\t\t}\n\t\t\t]\n\t\t}\n\t]\n}\n"
+      slack-access-token:
+        type: string
+        default: ''
+      slack-default-channel:
+        type: string
+        default: ''
     steps:
+      - when:
+          condition: << parameters.slack-access-token >> && << parameters.slack-default-channel >>
+          steps:
+            - run:
+                name: "Setup Slack environment variables"
+                command: |
+                  echo "export SLACK_ACCESS_TOKEN=<< parameters.slack-access-token >>" >> "$BASH_ENV"
+                  echo "export SLACK_DEFAULT_CHANNEL=<< parameters.slack-default-channel >>" >> "$BASH_ENV"
+                  source "$BASH_ENV"
+                when: on_fail
       - slack/notify:
           event: fail
-          custom: "{\n\t\"blocks\": [\n\t\t{\n\t\t\t\"type\": \"section\",\n\t\t\t\"text\": {\n\t\t\t\t\"type\": \"plain_text\",\n\t\t\t\t\"text\": \":red_circle: Failed: ${CIRCLE_USERNAME} workflow (${CIRCLE_JOB}) in ${CIRCLE_PROJECT_REPONAME} (${CIRCLE_BRANCH})\",\n\t\t\t\t\"emoji\": true\n\t\t\t}\n\t\t},\n\t\t{\n\t\t\t\"type\": \"actions\",\n\t\t\t\"elements\": [\n\t\t\t\t{\n\t\t\t\t\t\"type\": \"button\",\n\t\t\t\t\t\"text\": {\n\t\t\t\t\t\t\"type\": \"plain_text\",\n\t\t\t\t\t\t\"text\": \"View ${CIRCLE_PROJECT_REPONAME} ${CIRCLE_JOB} job\"\n\t\t\t\t\t},\n\t\t\t\t\t\"url\": \"${CIRCLE_BUILD_URL}\"\n\t\t\t\t}\n\t\t\t]\n\t\t}\n\t]\n}\n"
-
+          custom: << parameters.template >>
+  install_op:
+    description: Install 1Password CLI
+    parameters:
+      version:
+        type: string
+        default: '2.24.0'
+    steps:
+      - 1password/install-cli:
+          version: << parameters.version >>
+  upgrade_android_sdk:
+    description: Install Android requirements
+    parameters:
+      skip-upgrade:
+        type: boolean
+        default: false
+    steps:
+      - unless:
+          condition: << parameters.skip-upgrade >>
+          steps:
+            - run:
+                name: Installing Android Platform 28
+                command: |
+                  yes | sdkmanager "platforms;android-28" || true
 jobs:
   sentry-release:
     description: Create Sentry release and uploads sourcemaps from bundle

--- a/common/orb.yml
+++ b/common/orb.yml
@@ -554,7 +554,7 @@ commands:
       - slack/notify:
           event: fail
           custom: << parameters.template >>
-  install_op:
+  install-onepassword-cli:
     description: Install 1Password CLI
     parameters:
       version:
@@ -563,7 +563,7 @@ commands:
     steps:
       - 1password/install-cli:
           version: << parameters.version >>
-  upgrade_android_sdk:
+  upgrade-android-sdk:
     description: Install Android requirements
     parameters:
       skip-upgrade:

--- a/common/orb.yml
+++ b/common/orb.yml
@@ -544,7 +544,7 @@ commands:
       - 1password/install-cli:
           version: << parameters.version >>
   upgrade-android-sdk:
-    description: Install Android requirements
+    description: Upgrade Android SDK
     parameters:
       skip-upgrade:
         type: boolean


### PR DESCRIPTION
## Comandos añadidos:

- install-onepassword-cli -> instala el CLI de 1Password en la version 2.24.0 
- mac_vpn -> Configuración de conexión VPN para Mac
- update-android-sdk -> Instala/ Actualiza el SDK de Android

Estos tres comandos los utilizamos para proyectos de Plataforma, si los añadimos aquí será mucho más sencillo mantener todos los pipelines en caso de que actualicemos estas instrucciones. No los añadimos en un orb independiente porque son altamente reutilizables fuera de Plataforma.

## Comandos modificados:

okode/nofify:
- He añadido los parámetros `slack-access-token`, `slack-default-channel` y `template` para tener hacer más configurables las notificaciones del comando y poder reutilizarlas en los pipelines de Plataforma. Hasta ahora estábamos duplicando este comando y adaptándolo a nuestro pipeline. De esta forma es mucho más ágil. 
- El flujo de comportamiento por defecto sigue siendo el mismo. Por lo que en el resto de sitios donde se utilice este orb, no deberían ser afectados.
